### PR TITLE
fix bug in build.py

### DIFF
--- a/gerapy/server/core/build.py
+++ b/gerapy/server/core/build.py
@@ -49,7 +49,8 @@ def build_egg(project):
         project_path = join(path, project)
         os.chdir(project_path)
         settings = config(project_path, 'settings', 'default')
-        create_default_setup_py(project_path, settings=settings, project=project)
+        setup_file_path = join(project_path, 'setup.py')
+        create_default_setup_py(setup_file_path, settings=settings, project=project)
         d = tempfile.mkdtemp(prefix='gerapy-')
         o = open(os.path.join(d, 'stdout'), 'wb')
         e = open(os.path.join(d, 'stderr'), 'wb')
@@ -91,7 +92,7 @@ def create_default_setup_py(path, **kwargs):
     if os.path.exists(path):
         logger.debug('setup.py file already exists at %s', path)
     else:
-        with open(join(path, 'setup.py'), 'w', encoding='utf-8') as f:
+        with open(path, 'w', encoding='utf-8') as f:
             file = _SETUP_PY_TEMPLATE % kwargs
             f.write(file)
             f.close()


### PR DESCRIPTION
There is a bug in build.py:
The path passed to create_default_setup_py() is the folder path, not the absolute path of setup.py, which causes this function to never create setup.py.
The related issue #165 #164 