### PR TITLE
drop unsupported python 3.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.7
 WORKDIR /app
 COPY . /app/source
 COPY ./docker/run.sh /app/run.sh

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-cd /app
+cd /app || return
 gerapy init
-cd gerapy
+cd gerapy || return
 gerapy migrate
 gerapy initadmin
 gerapy runserver 0.0.0.0:8000

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ django-cors-headers>=3.2.0,<=3.7.0
 django-apscheduler>=0.3.0,<=0.6.0
 furl>=2.1.0
 jinja2>=2.11.3
-scrapy>=2.0.0
+scrapy>=2.7.1
 scrapy-redis>=0.6.8
 scrapy-splash>=0.7.2
 python-scrapyd-api>=2.1.2

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ DESCRIPTION = 'Distributed Crawler Management Framework Based on Scrapy, Scrapyd
 URL = 'https://github.com/Gerapy/Gerapy'
 EMAIL = 'cqc@cuiqingcai.com'
 AUTHOR = 'Germey'
-REQUIRES_PYTHON = '>=3.5.0'
+REQUIRES_PYTHON = '>=3.7.0'
 VERSION = None
 
 REQUIRED = read_requirements('requirements.txt')
@@ -114,8 +114,6 @@ setup(
     },
     classifiers=[
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
Python 3.6 is gone EOL around a year ago: https://endoflife.date/python
This PR is probably not complete and has still the deployment under the `deploy/` folder. I don't know how to proceed there though.