### PR TITLE
fix: support Scrapy >=2.6 where scrapy.item.BaseItem was removed

### DIFF
--- a/gerapy/server/core/parser.py
+++ b/gerapy/server/core/parser.py
@@ -4,7 +4,11 @@ from twisted.internet import reactor
 from scrapy.crawler import CrawlerRunner
 from scrapy.utils.project import get_project_settings
 from scrapy.http import Request
-from scrapy.item import BaseItem
+try:
+    # BaseItem was removed in Scrapy 2.6; fall back to Item on newer versions
+    from scrapy.item import BaseItem
+except ImportError:
+    from scrapy.item import Item as BaseItem
 from scrapy.utils.spider import iterate_spider_output
 from gerapy import get_logger
 from gerapy.server.core.utils import process_request, process_response, process_item


### PR DESCRIPTION
## Summary

Fixes the `ImportError: cannot import name 'BaseItem'` crash reported in #311 and #236.

## The problem

`gerapy/server/core/parser.py` did:

```python
from scrapy.item import BaseItem
```

`BaseItem` was **removed in Scrapy 2.6.0**. Since `pyproject.toml` requires `scrapy >= 2.7.1`, this import always fails on a fresh install, breaking the spider parser / debug feature (and any code path that imports `parser`).

## The fix

Import `BaseItem` when it exists (Scrapy < 2.6) and fall back to `Item` on newer versions, keeping the existing `isinstance(x, (BaseItem, dict))` check working on all supported Scrapy releases:

```python
try:
    # BaseItem was removed in Scrapy 2.6; fall back to Item on newer versions
    from scrapy.item import BaseItem
except ImportError:
    from scrapy.item import Item as BaseItem
```

On Scrapy ≥ 2.6 every user item subclasses `scrapy.Item`, so the `isinstance` check remains correct.

## Note on #236

#236 also mentions Twisted 22's removal of `HTTPClientFactory`. Gerapy does not reference `HTTPClientFactory` anywhere in its source (grep confirms zero usages), so the `BaseItem` import was the only Gerapy-side breakage; this change resolves it.

## Testing
- `python -m py_compile gerapy/server/core/parser.py` passes.

Closes #311
Closes #236