### PR TITLE
fix(security): validate URL before server-side fetch to prevent SSRF

### DIFF
--- a/gerapy/server/core/utils.py
+++ b/gerapy/server/core/utils.py
@@ -14,6 +14,9 @@ import os
 import string
 from shutil import move, copy, rmtree
 from os.path import join, exists, dirname
+from urllib.parse import urlparse
+import socket
+import ipaddress
 from django.utils import timezone
 from gerapy import get_logger
 from gerapy.settings import PROJECTS_FOLDER
@@ -34,6 +37,39 @@ TEMPLATES_TO_RENDER = (
 
 NO_REFERRER = '<meta name="referrer" content="never">'
 BASE = '<base href="{href}">'
+
+
+def is_safe_url(url):
+    """
+    Validate a user-supplied URL before fetching it server-side, to mitigate
+    SSRF (server-side request forgery). Only http/https URLs are allowed and the
+    target host must not resolve to a private, loopback, link-local, reserved or
+    otherwise non-global address (e.g. cloud metadata endpoints, localhost).
+    :param url: the URL to validate
+    :return: True if the URL is safe to fetch, otherwise False
+    """
+    try:
+        parsed = urlparse(url)
+    except (ValueError, AttributeError):
+        return False
+    if parsed.scheme not in ('http', 'https'):
+        return False
+    hostname = parsed.hostname
+    if not hostname:
+        return False
+    try:
+        addr_infos = socket.getaddrinfo(hostname, None)
+    except (socket.gaierror, UnicodeError):
+        return False
+    for addr_info in addr_infos:
+        ip = addr_info[4][0]
+        try:
+            ip_obj = ipaddress.ip_address(ip)
+        except ValueError:
+            return False
+        if not ip_obj.is_global:
+            return False
+    return True
 
 
 def get_scrapyd(client):

--- a/gerapy/server/core/views.py
+++ b/gerapy/server/core/views.py
@@ -26,7 +26,7 @@ from gerapy.server.server.settings import TIME_ZONE
 from gerapy.server.core.models import Client, Project, Deploy, Monitor, Task
 from gerapy.server.core.build import build_project, find_egg
 from gerapy.server.core.utils import IGNORES, is_in_curdir, scrapyd_url, log_url, get_tree, get_scrapyd, process_html, bytes2str, \
-    clients_of_task, get_job_id, log_exception
+    clients_of_task, get_job_id, log_exception, is_safe_url
 from django_apscheduler.models import DjangoJob, DjangoJobExecution
 from django.core.files.storage import FileSystemStorage
 import zipfile
@@ -968,6 +968,8 @@ def render_html(request):
     if request.method == 'GET':
         url = request.GET.get('url')
         url = unquote(base64.b64decode(url).decode('utf-8'))
+        if not is_safe_url(url):
+            return JsonResponse({'message': 'Invalid or forbidden URL'}, status=400)
         js = request.GET.get('js', 0)
         script = request.GET.get('script')
         response = requests.get(url, timeout=5)


### PR DESCRIPTION
## Summary

Fixes the "Full server-side request forgery" code-scanning alert tracked in #235 (CodeQL alert #29).

## The problem

`render_html` fetches a **fully user-controlled** URL:

```python
url = request.GET.get('url')
url = unquote(base64.b64decode(url).decode('utf-8'))
response = requests.get(url, timeout=5)   # <-- SSRF sink
```

An authenticated user could make the server request internal-only resources — cloud metadata (`http://169.254.169.254/`), loopback services (`http://127.0.0.1/`), or private-network hosts — or use non-HTTP schemes.

## The fix

Added an `is_safe_url()` helper in `utils.py` and call it before the fetch in `render_html`. The helper:

- allows only `http` / `https` schemes;
- resolves the hostname and rejects the request if **any** resolved address is non-global (private, loopback, link-local, reserved, unspecified) via `ipaddress.ip_address(...).is_global`.

```python
if not is_safe_url(url):
    return JsonResponse({'message': 'Invalid or forbidden URL'}, status=400)
```

## Testing

Verified the guard against representative inputs (all pass):

| URL | Allowed |
|---|---|
| `https://example.com`, `https://8.8.8.8` | ✅ yes |
| `http://127.0.0.1:8000`, `http://localhost/` | ⛔ no |
| `http://169.254.169.254/latest/meta-data` | ⛔ no |
| `http://10.0.0.5/` | ⛔ no |
| `file:///etc/passwd`, `gopher://evil/x` | ⛔ no |

> Note: the other `requests.get` sinks (`job_log`, `index_status`, `client_status`) build their URL from admin-configured `Client` records, not from request input, so they are out of scope for this alert.

Closes #235