### PR TITLE
fix(scheduler): configure apscheduler job defaults to stop missed/blocked jobs

### DIFF
--- a/gerapy/server/core/scheduler.py
+++ b/gerapy/server/core/scheduler.py
@@ -6,10 +6,15 @@ from apscheduler.schedulers.background import BackgroundScheduler
 from django_apscheduler.jobstores import DjangoJobStore, register_events
 from gerapy import get_logger
 from gerapy.server.core.models import Client, Task
-from gerapy.settings import SCHEDULER_HEARTBEAT
+from gerapy.settings import SCHEDULER_HEARTBEAT, SCHEDULER_COALESCE, SCHEDULER_MAX_INSTANCES, \
+    SCHEDULER_MISFIRE_GRACE_TIME
 from gerapy.server.core.utils import get_scrapyd, clients_of_task, get_job_id
 
-scheduler = BackgroundScheduler()
+scheduler = BackgroundScheduler(job_defaults={
+    'coalesce': SCHEDULER_COALESCE,
+    'max_instances': SCHEDULER_MAX_INSTANCES,
+    'misfire_grace_time': SCHEDULER_MISFIRE_GRACE_TIME,
+})
 scheduler.add_jobstore(DjangoJobStore(), 'default')
 
 # map the args

--- a/gerapy/settings.py
+++ b/gerapy/settings.py
@@ -19,6 +19,13 @@ PROJECTS_FOLDER = getenv('PROJECTS_FOLDER', 'projects')
 LOGS_FOLDER = LOG_DIR
 # scheduler
 SCHEDULER_HEARTBEAT = 3
+# apscheduler job defaults. The library defaults (misfire_grace_time=1s,
+# max_instances=1) cause "Run time of job ... was missed!" warnings and skipped
+# runs whenever the scheduler thread is briefly busy or a scrapyd request is
+# slow. coalesce=True collapses several missed runs into a single one.
+SCHEDULER_COALESCE = getenv('SCHEDULER_COALESCE', True)
+SCHEDULER_MAX_INSTANCES = int(getenv('SCHEDULER_MAX_INSTANCES', 10))
+SCHEDULER_MISFIRE_GRACE_TIME = int(getenv('SCHEDULER_MISFIRE_GRACE_TIME', 3600))
 
 ADMINS = [
     'admin'


### PR DESCRIPTION
## Summary

Fixes the recurring scheduler problems reported in #316 ("Run time of job '…' was missed!") and #248 (timed tasks stop firing / countdown goes negative). Both share one root cause.

## Root cause

`scheduler.py` created the scheduler with **no job defaults**:

```python
scheduler = BackgroundScheduler()
```

APScheduler then applies its strict library defaults to every job:

- `misfire_grace_time = 1` (second) — if the background thread is briefly busy, or the `scrapyd.schedule()` HTTP call is slow, the job is already "late" and gets **dropped** with *"Run time of job … was missed!"* (#316).
- `max_instances = 1` — if one run hangs (e.g. an unreachable scrapyd), every later trigger is skipped with *"maximum number of running instances reached"*, so the task **silently stops running** (#248).
- no `coalesce`, so after any downtime a backlog of missed runs can pile up.

## The fix

Configure sensible, override-able job defaults (new settings in `gerapy/settings.py`, read from env):

```python
scheduler = BackgroundScheduler(job_defaults={
    'coalesce': SCHEDULER_COALESCE,              # default True
    'max_instances': SCHEDULER_MAX_INSTANCES,    # default 10
    'misfire_grace_time': SCHEDULER_MISFIRE_GRACE_TIME,  # default 3600s
})
```

- `misfire_grace_time=3600` — a run that is a little late still fires instead of being dropped.
- `max_instances=10` — a slow/hung run no longer permanently blocks the schedule.
- `coalesce=True` — multiple missed runs collapse into a single execution (no flood after downtime).

All three are tunable via `SCHEDULER_MISFIRE_GRACE_TIME`, `SCHEDULER_MAX_INSTANCES`, `SCHEDULER_COALESCE` environment variables.

## Testing
- `python -m py_compile` passes for both files.

Closes #316
Closes #248