### PR TITLE
fix(db): raise SQLite busy timeout to reduce "database is locked" errors

### DIFF
--- a/gerapy/server/server/settings.py
+++ b/gerapy/server/server/settings.py
@@ -94,6 +94,13 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
         'NAME': DB_PATH,
+        # SQLite locks the whole database on write. The background scheduler and
+        # the web server write concurrently, so the default 5s busy timeout is
+        # easily exceeded and raises "database is locked". A longer timeout makes
+        # writers wait for the lock instead of failing. Tune via SQLITE_TIMEOUT.
+        'OPTIONS': {
+            'timeout': int(os.getenv('SQLITE_TIMEOUT', 20)),
+        },
     }
 }
 


### PR DESCRIPTION
## Summary

Reduces the `django.db.utils.OperationalError: database is locked` errors reported in #244 and #237.

## Root cause

Gerapy uses SQLite, which takes a **database-wide lock on every write**. Two writers run concurrently:

- the background `SchedulerManager` thread (django-apscheduler persists job state / executions every few seconds), and
- the Django web server handling API requests.

The SQLite backend's default busy timeout is only ~5s, so under this concurrency a writer that can't immediately get the lock raises *"database is locked"* instead of waiting.

## The fix

Set a longer busy `timeout` on the SQLite connection so a blocked writer waits for the lock to be released rather than failing immediately:

```python
'OPTIONS': {
    'timeout': int(os.getenv('SQLITE_TIMEOUT', 20)),
},
```

Configurable via the `SQLITE_TIMEOUT` environment variable (default 20s).

## Notes
- This is the canonical Django + SQLite remedy for lock contention and is low-risk.
- For very write-heavy deployments, enabling WAL journal mode or moving to MySQL/PostgreSQL further improves concurrency; the timeout above resolves the common case reported here.

## Testing
- `python -m py_compile` passes.

Closes #244
Closes #237