### PR TITLE
fix(scheduler): include client id in job id to avoid multi-host scheduling collisions

### DIFF
--- a/gerapy/server/core/utils.py
+++ b/gerapy/server/core/utils.py
@@ -448,7 +448,10 @@ def get_job_id(client, task):
     :param task: task object
     :return: job id
     """
-    return '%s-%s-%s' % (client.name, task.project, task.spider)
+    # include the client's primary key so that clients sharing the same name do
+    # not collide on the same job id (which, with replace_existing=True, would
+    # cause some selected hosts to silently not be scheduled)
+    return '%s-%s-%s-%s' % (client.id, client.name, task.project, task.spider)
 
 
 def load_dict(x, transformer=None):


### PR DESCRIPTION
## Summary

Fixes #252: when a task is scheduled to several hosts, only some of them actually get scheduled.

## Root cause

Job ids are built from the client **name** only:

```python
def get_job_id(client, task):
    return '%s-%s-%s' % (client.name, task.project, task.spider)
```

The `Client.name` field has **no unique constraint** (`name = CharField(max_length=255, default=None)`), so two clients can share a name. When they do, they produce the **same job id**, and the scheduler adds jobs with `replace_existing=True`:

```python
self.scheduler.add_job(execute, ..., id=job_id, replace_existing=True, **configuration)
```

so the later client's job overwrites the earlier one — the colliding hosts collapse into a single job and the rest are silently "not scheduled", exactly matching the report.

## The fix

Include the client's primary key (guaranteed unique) in the job id:

```python
return '%s-%s-%s-%s' % (client.id, client.name, task.project, task.spider)
```

Each selected host now gets a distinct job. The id change is self-healing: on the next sync tick the old-format jobs are treated as deprecated and pruned by `_remove_deprecated_jobs`, and fresh per-client jobs are created.

## Testing
- `python -m py_compile` passes.

Closes #252